### PR TITLE
Add support for application/x-www-form-urlencoded

### DIFF
--- a/__test_api__/sample-serv.yaml
+++ b/__test_api__/sample-serv.yaml
@@ -102,6 +102,39 @@ paths:
           description: Pet deleted
         404:
           description: Pet not found
+  /pets/{pet_id}/form:
+    put:
+      summary: Update a pet with form data
+      operationId: updatePetWithForm
+      parameters:
+        - name: pet_id
+          in: path
+          required: true
+          description: The id of the pet to update
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  description: Name of the pet
+                status:
+                  type: string
+                  description: Status of the pet
+      responses:
+        200:
+          description: Pet updated
+        400:
+          description: Invalid input
+      x-codegen-request-body-name: formData
   /pets/photo:
     post:
       summary: Upload a photo for a pet

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasbuddy/small-openapi-codegen",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Parse an OpenAPI spec and generate fetch-based clients for Javascript environments (React Native and Node 12+)",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "mkdirp": "^1.0.4",
     "openapi-types": "^12.0.2",
     "prettier": "^3.3.3",
-    "rest-api-support": "2.0.0-beta.7"
+    "rest-api-support": "2.0.0-beta.8"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/src/handlebars-setup.ts
+++ b/src/handlebars-setup.ts
@@ -111,11 +111,27 @@ export default function setupHandlebars(options: Record<string, any>) {
   );
 
   handlebars.registerHelper(
+    'isFormUrlEncoded',
+    (spec: Record<string, Record<string, any>>) => !!spec?.content?.['application/x-www-form-urlencoded'],
+  );
+
+  handlebars.registerHelper(
     'getMultipartFormDataProperties',
     (spec: Record<string, Record<string, any>>) => {
       const multipartSchema = spec?.content?.['multipart/form-data']?.schema;
       if (multipartSchema?.type === 'object' && multipartSchema.properties) {
         return getFriendlyProperties(multipartSchema);
+      }
+      return [];
+    },
+  );
+
+  handlebars.registerHelper(
+    'getFormUrlEncodedProperties',
+    (spec: Record<string, Record<string, any>>) => {
+      const formSchema = spec?.content?.['application/x-www-form-urlencoded']?.schema;
+      if (formSchema?.type === 'object' && formSchema.properties) {
+        return getFriendlyProperties(formSchema);
       }
       return [];
     },

--- a/src/templates/ts/index.handlebars
+++ b/src/templates/ts/index.handlebars
@@ -33,6 +33,7 @@ export class {{{options.className}}} {
   }
 
 {{#each (methods paths)}}
+
 {{>method .}}
 
 {{/each}}

--- a/src/templates/ts/method.handlebars
+++ b/src/templates/ts/method.handlebars
@@ -16,6 +16,12 @@
       {{js name}}{{#unless isRequired}}?{{/unless}}: {{>type .}};
     {{/each}}
     }
+  {{else if (isFormUrlEncoded requestBody)}}
+    {
+    {{#each (getFormUrlEncodedProperties requestBody)}}
+      {{js name}}{{#unless isRequired}}?{{/unless}}: {{>type .}};
+    {{/each}}
+    }
   {{else}}
     {{>type (get 'schema' (json requestBody))}}
   {{/if}},
@@ -37,6 +43,12 @@
   {{#if (isMultipartFormData requestBody)}}
     {
     {{#each (getMultipartFormDataProperties requestBody)}}
+      {{js name}}{{#unless isRequired}}?{{/unless}}: {{>type .}};
+    {{/each}}
+    }
+  {{else if (isFormUrlEncoded requestBody)}}
+    {
+    {{#each (getFormUrlEncodedProperties requestBody)}}
       {{js name}}{{#unless isRequired}}?{{/unless}}: {{>type .}};
     {{/each}}
     }
@@ -87,6 +99,9 @@ $$fetchOptions?: FetchPerRequestOptions,
         '{{name}}',
         request.{{#if ../../x-codegen-request-body-name}}{{js ../../x-codegen-request-body-name}}{{else}}body{{/if}}.{{js name}}{{#if isBinary}}, request.options?.{{js name}}{{else if isFileArray}}, request.options?.{{js name}}{{/if}})
         {{/each}}
+      {{else if (isFormUrlEncoded requestBody)}}
+      .formUrlEncoded(
+        request.{{#if (get "x-codegen-request-body-name")}}{{js (get "x-codegen-request-body-name")}}{{else}}body{{/if}})
       {{else}}
       .body(
         '{{#if (get "x-codegen-request-body-name")}}{{js (get "x-codegen-request-body-name")}}{{else}}body{{/if}}',

--- a/src/templates/ts/package.handlebars
+++ b/src/templates/ts/package.handlebars
@@ -20,7 +20,7 @@
     "typescript": "^4.8.4"
   },
   "dependencies": {
-    "rest-api-support": "^2.0.0-beta.7"
+    "rest-api-support": "^2.0.0-beta.8"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -518,7 +518,7 @@ __metadata:
     mkdirp: ^1.0.4
     openapi-types: ^12.0.2
     prettier: ^3.3.3
-    rest-api-support: 2.0.0-beta.7
+    rest-api-support: 2.0.0-beta.8
     ts-jest: ^29.0.3
     typescript: ^4.8.4
   bin:
@@ -6872,12 +6872,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rest-api-support@npm:2.0.0-beta.7":
-  version: 2.0.0-beta.7
-  resolution: "rest-api-support@npm:2.0.0-beta.7"
+"rest-api-support@npm:2.0.0-beta.8":
+  version: 2.0.0-beta.8
+  resolution: "rest-api-support@npm:2.0.0-beta.8"
   dependencies:
     query-string: ^7.1.1
-  checksum: c4ee8d90546d354ec1f853d751e4da6df73384966abbac6ab8b7e8128b01d7e733d8d250e1eb60796590249ccdda1fb133ca13bd9e91844604ef67590fd40039
+  checksum: 1c5653e1190c786cd398ad5c9c11ae0f822de87eccab8dca95d56dad8142b76e69620bc5453a037e437c0eaf69aa14867120029715618c90df3b8721a62143d7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request includes updates to the OpenAPI spec and enhancements to the Handlebars templates to support form URL encoded requests. Additionally, it includes version updates for dependencies in the `package.json` and `package.handlebars` files.

Enhancements to OpenAPI spec and Handlebars templates:

* [`__test_api__/sample-serv.yaml`](diffhunk://#diff-308a2b360372f208e19867d3a9a71add8ba79b332a3e5e2d72d6d5e143238bd7R105-R137): Added a new endpoint `/pets/{pet_id}/form` to update a pet with form data.
* [`src/handlebars-setup.ts`](diffhunk://#diff-af2bf9f97ad40ff0d3931de40073915d72aea04d7438a2436d989a42aba9aa23R113-R117): Added Handlebars helpers `isFormUrlEncoded` and `getFormUrlEncodedProperties` to handle form URL encoded requests. [[1]](diffhunk://#diff-af2bf9f97ad40ff0d3931de40073915d72aea04d7438a2436d989a42aba9aa23R113-R117) [[2]](diffhunk://#diff-af2bf9f97ad40ff0d3931de40073915d72aea04d7438a2436d989a42aba9aa23R129-R139)
* [`src/templates/ts/method.handlebars`](diffhunk://#diff-cb9531cbbd0ba926033f8afcb3eed7a3407ac855fb7799907a41cec59cf92ab8R19-R24): Updated to support form URL encoded request bodies by adding conditions to check for `isFormUrlEncoded` and using `getFormUrlEncodedProperties`. [[1]](diffhunk://#diff-cb9531cbbd0ba926033f8afcb3eed7a3407ac855fb7799907a41cec59cf92ab8R19-R24) [[2]](diffhunk://#diff-cb9531cbbd0ba926033f8afcb3eed7a3407ac855fb7799907a41cec59cf92ab8R49-R54) [[3]](diffhunk://#diff-cb9531cbbd0ba926033f8afcb3eed7a3407ac855fb7799907a41cec59cf92ab8R102-R104)

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version of the package to `0.2.10` and updated the `rest-api-support` dependency to `2.0.0-beta.8`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L56-R56)
* [`src/templates/ts/package.handlebars`](diffhunk://#diff-2ee16759e71619758c9bfabde16aba68c83797d82a6f9e88e05bf67ed325ec33L23-R23): Updated the `rest-api-support` dependency to `2.0.0-beta.8`.