### PR TITLE
Update to send body for formData

### DIFF
--- a/__test_api__/sample-serv.yaml
+++ b/__test_api__/sample-serv.yaml
@@ -189,8 +189,111 @@ paths:
         400:
           description: Invalid input
       x-codegen-request-body-name: request
+  /pets/search:
+    post:
+      summary: Search pets
+      operationId: searchPets
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - search_terms
+              properties:
+                search_terms:
+                  type: string
+                max_results:
+                  type: integer
+                filters:
+                  type: object
+                  properties:
+                    species:
+                      type: string
+                    min_weight:
+                      type: number
+                    max_weight:
+                      type: number
+      responses:
+        200:
+          description: Search results
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+      x-codegen-request-body-name: request
+  /pets/update:
+    put:
+      summary: Update a pet with form data
+      operationId: updatePetWithFormRef
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PetFormData'
+      responses:
+        200:
+          description: Pet updated
+        400:
+          description: Invalid input
+      x-codegen-request-body-name: formData
+  /pets/upload:
+    post:
+      summary: Upload a pet photo with document
+      operationId: uploadPetPhotoWithDoc
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PetPhotoUpload'
+      responses:
+        200:
+          description: Photo uploaded
+        400:
+          description: Invalid input
+      x-codegen-request-body-name: request
 components:
   schemas:
+    PetFormData:
+      type: object
+      required:
+        - name
+        - id
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+          description: Name of the pet
+        status:
+          type: string
+          description: Status of the pet
+    PetPhotoUpload:
+      type: object
+      required:
+        - pet_id
+        - photo
+      properties:
+        pet_id:
+          type: integer
+          format: int64
+        photo:
+          type: string
+          format: binary
+        metadata:
+          type: object
+          properties:
+            title:
+              type: string
+            date:
+              type: string
+              format: date
     Address:
       type: object
       description: An address
@@ -207,7 +310,7 @@ components:
         state:
           type: string
           description: State or province
-        zipCode:
+        zip_code:
           type: string
           description: Postal code
     Pet:
@@ -262,7 +365,7 @@ components:
             breed:
               type: string
               description: The breed of the pet
-            birthDate:
+            birth_date:
               type: string
               format: date
             color:

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -170,6 +170,34 @@ describe('small-openapi-codegen', () => {
       expect(indexOutput!.output).toContain('uploadPetPhotos(');
       expect(indexOutput!.output).toContain('photos: Array<Buffer | string>;');
     });
+
+    test('handles schema references in form-urlencoded requests', async () => {
+      const spec = await readSpec(sampleSpecPath, { snake: true });
+      const outputs = await render(mockTsModel, spec, {});
+
+      const indexOutput = outputs.find(
+        (output) => (typeof output.filename === 'function' ? output.filename() : output.filename) === 'src/index.ts',
+      );
+
+      // Check for formUrlEncoded with reference
+      expect(indexOutput!.output).toContain('updatePetWithFormRef');
+      expect(indexOutput!.output).toContain('export interface PetFormData');
+      expect(indexOutput!.output).toContain('formUrlEncoded');
+    });
+
+    test('handles schema references in multipart/form-data requests', async () => {
+      const spec = await readSpec(sampleSpecPath, { snake: true });
+      const outputs = await render(mockTsModel, spec, {});
+
+      const indexOutput = outputs.find(
+        (output) => (typeof output.filename === 'function' ? output.filename() : output.filename) === 'src/index.ts',
+      );
+
+      // Check for multipart/form-data with reference
+      expect(indexOutput!.output).toContain('uploadPetPhotoWithDoc');
+      expect(indexOutput!.output).toContain('export interface PetPhotoUpload');
+      expect(indexOutput!.output).toContain('formData');
+    });
   });
 
   describe('Response types', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasbuddy/small-openapi-codegen",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Parse an OpenAPI spec and generate fetch-based clients for Javascript environments (React Native and Node 12+)",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "copy-templates": "copyfiles -u 1 \"src/**/*.handlebars\" build",
     "clean": "yarn dlx rimraf ./build",
     "prepare": "husky install",
-    "test-client": "rm -rf test-client && node build/bin/small-openapi-codegen.js __test_api__/sample-serv.yaml --output test-client --name test-client",
+    "test-client": "rm -rf test-client && node build/bin/small-openapi-codegen.js __test_api__/sample-serv.yaml --output test-client --name test-client --snake",
     "build-and-test-client": "yarn build && yarn test-client"
   },
   "bin": "build/bin/small-openapi-codegen.js",
@@ -55,7 +55,7 @@
     "mkdirp": "^1.0.4",
     "openapi-types": "^12.0.2",
     "prettier": "^3.3.3",
-    "rest-api-support": "2.0.0-beta.9"
+    "rest-api-support": "2.0.0-beta.10"
   },
   "packageManager": "yarn@3.2.4"
 }

--- a/src/templates/ts/method.handlebars
+++ b/src/templates/ts/method.handlebars
@@ -11,60 +11,28 @@
 {{#if requestBody}}
   {{#if (get "x-codegen-request-body-name")}}{{js (get "x-codegen-request-body-name")}}{{else}}body{{/if}}:
   {{#if (isMultipartFormData requestBody)}}
-    {
-    {{#each (getMultipartFormDataProperties requestBody)}}
-      {{js name}}{{#unless isRequired}}?{{/unless}}: {{>type .}};
-    {{/each}}
-    }
+    {{>type (get 'schema' requestBody.content.[multipart/form-data])}}
   {{else if (isFormUrlEncoded requestBody)}}
-    {
-    {{#each (getFormUrlEncodedProperties requestBody)}}
-      {{js name}}{{#unless isRequired}}?{{/unless}}: {{>type .}};
-    {{/each}}
-    }
+    {{>type (get 'schema' requestBody.content.[application/x-www-form-urlencoded])}}
   {{else}}
     {{>type (get 'schema' (json requestBody))}}
   {{/if}},
   {{#if (isMultipartFormData requestBody)}}
-  options?: {
-    {{#each (getMultipartFormDataProperties requestBody)}}
-    {{#if isBinary}}
-    {{js name}}?: { filename?: string; contentType?: string } | { filename?: string; contentType?: string }[];
-    {{else if isFileArray}}
-    {{js name}}?: { filename?: string; contentType?: string } | { filename?: string; contentType?: string }[];
-    {{/if}}
-    {{/each}}
-  },
+  options?: Record<string, { filename?: string; contentType?: string } | { filename?: string; contentType?: string }[]>,
   {{/if}}
 {{/if}}
   }, {{else if requestBody}}
   request: {
   {{#if (get "x-codegen-request-body-name")}}{{js (get "x-codegen-request-body-name")}}{{else}}body{{/if}}:
   {{#if (isMultipartFormData requestBody)}}
-    {
-    {{#each (getMultipartFormDataProperties requestBody)}}
-      {{js name}}{{#unless isRequired}}?{{/unless}}: {{>type .}};
-    {{/each}}
-    }
+    {{>type (get 'schema' requestBody.content.[multipart/form-data])}}
   {{else if (isFormUrlEncoded requestBody)}}
-    {
-    {{#each (getFormUrlEncodedProperties requestBody)}}
-      {{js name}}{{#unless isRequired}}?{{/unless}}: {{>type .}};
-    {{/each}}
-    }
+    {{>type (get 'schema' requestBody.content.[application/x-www-form-urlencoded])}}
   {{else}}
     {{>type (get 'schema' (json requestBody))}}
   {{/if}},
   {{#if (isMultipartFormData requestBody)}}
-  options?: {
-    {{#each (getMultipartFormDataProperties requestBody)}}
-    {{#if isBinary}}
-    {{js name}}?: { filename?: string; contentType?: string } | { filename?: string; contentType?: string }[];
-    {{else if isFileArray}}
-    {{js name}}?: { filename?: string; contentType?: string } | { filename?: string; contentType?: string }[];
-    {{/if}}
-    {{/each}}
-  },
+  options?: Record<string, { filename?: string; contentType?: string } | { filename?: string; contentType?: string }[]>,
   {{/if}}
   },
   {{else}}
@@ -96,11 +64,10 @@ $$fetchOptions?: FetchPerRequestOptions,
     {{/each}}
     {{#if requestBody}}
       {{#if (isMultipartFormData requestBody)}}
-        {{#each (getMultipartFormDataProperties requestBody)}}
       .formData(
-        '{{name}}',
-        request.{{#if ../../x-codegen-request-body-name}}{{js ../../x-codegen-request-body-name}}{{else}}body{{/if}}.{{js name}}{{#if isBinary}}, request.options?.{{js name}}{{else if isFileArray}}, request.options?.{{js name}}{{/if}})
-        {{/each}}
+        request.{{#if (get "x-codegen-request-body-name")}}{{js (get "x-codegen-request-body-name")}}{{else}}body{{/if}},
+        request.options
+      )
       {{else if (isFormUrlEncoded requestBody)}}
       .formUrlEncoded(
         request.{{#if (get "x-codegen-request-body-name")}}{{js (get "x-codegen-request-body-name")}}{{else}}body{{/if}})

--- a/src/templates/ts/package.handlebars
+++ b/src/templates/ts/package.handlebars
@@ -20,6 +20,6 @@
     "typescript": "^4.8.4"
   },
   "dependencies": {
-    "rest-api-support": "^2.0.0-beta.9"
+    "rest-api-support": "^2.0.0-beta.10"
   }
 }

--- a/src/templates/ts/type.handlebars
+++ b/src/templates/ts/type.handlebars
@@ -1,8 +1,8 @@
 {{#if (eq type 'array')}}Array<{{>type items}}>{{
   else if (eq type 'object')}}
-  {{#if (length (properties .))}}{{#forEach (properties .)}}{{#if isFirst}}{ {{/if}}
-    {{name}}{{#unless isRequired}}?{{/unless}}: {{>type .}};
-  {{#if isLast}} }{{/if}}{{/forEach}}
+  {{#if (length (properties .))}}{{#forEach (properties .)}}{{#if isFirst}}{ 
+{{/if}}  {{name}}{{#unless isRequired}}?{{/unless}}: {{>type .}};
+{{#if isLast}} }{{/if}}{{/forEach}}
   {{else}}
     Record<string, any>
   {{/if}}

--- a/yarn.lock
+++ b/yarn.lock
@@ -519,7 +519,7 @@ __metadata:
     mkdirp: ^1.0.4
     openapi-types: ^12.0.2
     prettier: ^3.3.3
-    rest-api-support: 2.0.0-beta.9
+    rest-api-support: 2.0.0-beta.10
     rimraf: ^3.0.2
     ts-jest: ^29.0.3
     typescript: ^4.8.4
@@ -6901,12 +6901,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rest-api-support@npm:2.0.0-beta.9":
-  version: 2.0.0-beta.9
-  resolution: "rest-api-support@npm:2.0.0-beta.9"
+"rest-api-support@npm:2.0.0-beta.10":
+  version: 2.0.0-beta.10
+  resolution: "rest-api-support@npm:2.0.0-beta.10"
   dependencies:
     query-string: ^7.1.1
-  checksum: 3b7410e8e906cf19fce2c2ec2ea6d9e8776fef5d7080d9c0ef952d85f904c84e3b02aae507d371712e4a7c223b89ddc53768ad16c5476df22c9a5828b6b250be
+  checksum: 1034c4de910467589133e592a0eb429f21bf9da32ebd97d9789914293752f46119af6ebe88aac27bf2ee50501ecda2a22fca474a250650f239fdc3f9b9bbc3e1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the OpenAPI code generation logic, including support for schema references in form-urlencoded and multipart/form-data requests, and adjustments to dependencies and templates. Below is a breakdown of the most important changes:

### Code Generation Improvements
* Enhanced the TypeScript templates (`method.handlebars`, `type.handlebars`) to handle schema references for `application/x-www-form-urlencoded` and `multipart/form-data` requests. This simplifies the generated code and ensures better maintainability. [[1]](diffhunk://#diff-cb9531cbbd0ba926033f8afcb3eed7a3407ac855fb7799907a41cec59cf92ab8L14-R35) [[2]](diffhunk://#diff-ac5fb021dd86b5eef7d0642c47c77715f89b57510a5f8cd81325d8effb65598cL3-R4)
* Adjusted the logic for handling `options` in multipart/form-data requests to use a `Record<string, { filename?: string; contentType?: string }[]>` structure, improving clarity and flexibility.

### Testing Enhancements
* Added new test cases in `index.spec.ts` to validate the handling of schema references in form-urlencoded and multipart/form-data requests, ensuring the correctness of the generated code.

### Dependency Updates
* Upgraded the `rest-api-support` dependency to version `2.0.0-beta.10` in both `package.json` and the TypeScript template's `package.handlebars` file. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L58-R58) [[2]](diffhunk://#diff-2ee16759e71619758c9bfabde16aba68c83797d82a6f9e88e05bf67ed325ec33L23-R23)

### Build Script Updates
* Modified the `test-client` script in `package.json` to include the `--snake` option, aligning the generated client code with the updated snake_case property naming convention.