### PR TITLE
Add @types/node and yarnrc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasbuddy/small-openapi-codegen",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Parse an OpenAPI spec and generate fetch-based clients for Javascript environments (React Native and Node 12+)",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/templates/ts/index.ts
+++ b/src/templates/ts/index.ts
@@ -28,6 +28,10 @@ const tsModel: LanguageModel = {
       source: path.resolve(__dirname, 'yarn.handlebars'),
       filename: () => 'yarn.lock',
     },
+    {
+      source: path.resolve(__dirname, 'yarnrc.handlebars'),
+      filename: () => '.yarnrc.yml',
+    },
     partial('schema'),
     partial('type'),
     partial('method'),

--- a/src/templates/ts/package.handlebars
+++ b/src/templates/ts/package.handlebars
@@ -20,6 +20,7 @@
     "typescript": "^4.8.4"
   },
   "dependencies": {
+    "@types/node": "^18.0.0",
     "rest-api-support": "^2.0.0-beta.10"
   }
 }

--- a/src/templates/ts/yarnrc.handlebars
+++ b/src/templates/ts/yarnrc.handlebars
@@ -1,0 +1,1 @@
+nodeLinker: node-modules


### PR DESCRIPTION
This pull request introduces changes to enhance TypeScript project templates by adding support for `.yarnrc.yml` configuration and updating dependencies. The most important changes focus on adding new template files and updating package configurations.

### Enhancements to TypeScript project templates:

* **Added support for `.yarnrc.yml` configuration:**
  * Introduced a new template file `yarnrc.handlebars` with the `nodeLinker: node-modules` configuration. (`src/templates/ts/yarnrc.handlebars`)
  * Updated the `tsModel` in `index.ts` to include the `.yarnrc.yml` file generation logic. (`src/templates/ts/index.ts`)

* **Updated package dependencies:**
  * Added `@types/node` version `^18.0.0` to the `dependencies` section in the `package.handlebars` template. (`src/templates/ts/package.handlebars`)